### PR TITLE
Disable M106 gcode_macro in printer.cfg for n4

### DIFF
--- a/Elegoo/Neptune 4/printer.cfg
+++ b/Elegoo/Neptune 4/printer.cfg
@@ -683,21 +683,21 @@ gcode:
   PAUSE
   M400
 
-[gcode_macro M106]
-rename_existing: M99106
-gcode:
-    {% if 'S' in params %}
-    {% set s = (params.S|float, 255)|min %}
-      {% if (printer.toolhead.fan_mode) == 0 %}
-        MKS_M106 S={(204, s)|min}
-      {% endif %}
-      {% if (printer.toolhead.fan_mode) == 1 %}
-        MKS_M106 S={(153, s)|min}
-      {% endif %}
-      {% if (printer.toolhead.fan_mode) == 2 %}
-        MKS_M106 S={s}
-      {% endif %}
-    {% endif %}
+#[gcode_macro M106]
+#rename_existing: M99106
+#gcode:
+#    {% if 'S' in params %}
+#    {% set s = (params.S|float, 255)|min %}
+#      {% if (printer.toolhead.fan_mode) == 0 %}
+#        MKS_M106 S={(204, s)|min}
+#      {% endif %}
+#      {% if (printer.toolhead.fan_mode) == 1 %}
+#        MKS_M106 S={(153, s)|min}
+#      {% endif %}
+#      {% if (printer.toolhead.fan_mode) == 2 %}
+#        MKS_M106 S={s}
+#      {% endif %}
+#    {% endif %}
 
 ################ Buzzer configuration ##################
 [output_pin beeper]


### PR DESCRIPTION
Comment out the M106 gcode_macro for fan control.